### PR TITLE
ignore backend path and query

### DIFF
--- a/balance/handler.go
+++ b/balance/handler.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"path"
 	"regexp"
 	"strings"
 
@@ -71,12 +70,6 @@ func (h *Handler) direct(r *http.Request) error {
 
 	r.URL.Scheme = b.URL.Scheme
 	r.URL.Host = b.URL.Host
-	r.URL.Path = path.Join(b.URL.Path, r.URL.Path)
-	if b.URL.RawQuery == "" || r.URL.RawQuery == "" {
-		r.URL.RawQuery = b.URL.RawQuery + r.URL.RawQuery
-	} else {
-		r.URL.RawQuery = b.URL.RawQuery + "&" + r.URL.RawQuery
-	}
 
 	log.WithFields(log.Fields{
 		"id":  transaction.ID(r),

--- a/balance/handler_test.go
+++ b/balance/handler_test.go
@@ -50,7 +50,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		{ // if there're multiple backends available, it spreads the workload across them.
 			backends: []*Backend{
 				{URL: &url.URL{Scheme: "https", Host: "a.example.com"}},
-				{URL: &url.URL{Scheme: "https", Host: "b.example.com"}},
+				{URL: &url.URL{Scheme: "https", Host: "b.example.com", Path:"/path/ignored", RawQuery:"query=ignored"}},
 				{URL: &url.URL{Scheme: "https", Host: "c.example.com"}},
 			},
 			givenReqs: []*http.Request{


### PR DESCRIPTION
It'll be better if we can use `-backend` to point arbitrary health-checking paths but not backend roots.